### PR TITLE
Suppress exceptions by malformed LOG, such as:

### DIFF
--- a/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
+++ b/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
@@ -841,9 +841,12 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
     // Utilities
 
     private static void LOG(String message, Object... args) {
-        if (args != null)
-            message = String.format(message, args);
-        Log.d("EasyVideoPlayer", message);
+        try {
+            if (args != null)
+                message = String.format(message, args);
+            Log.d("EasyVideoPlayer", message);
+        } catch (MissingFormatArgumentException ignored) {
+        }
     }
 
     private void invalidateActions() {

--- a/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
+++ b/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
@@ -355,7 +355,8 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
             if (mCallback != null)
                 mCallback.onPreparing(this);
             mPlayer.setSurface(mSurface);
-            if (mSource.getScheme().equals("http") || mSource.getScheme().equals("https")) {
+            if (mSource.getScheme() != null &&
+                    (mSource.getScheme().equals("http") || mSource.getScheme().equals("https"))) {
                 LOG("Loading web URI: " + mSource.toString());
                 mPlayer.setDataSource(mSource.toString());
             } else {


### PR DESCRIPTION
Fatal Exception: java.util.MissingFormatArgumentException
Format specifier: 20V

Signed-off-by: Francisco Franco <franciscofranco.1990@gmail.com>