### PR TITLE
Checks if mCallback is null on pause

### DIFF
--- a/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
+++ b/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
@@ -579,7 +579,7 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
     public void pause() {
         if (mPlayer == null || !isPlaying()) return;
         mPlayer.pause();
-        mCallback.onPaused(this);
+        if (mCallback != null) mCallback.onPaused(this);
         if (mHandler == null) return;
         mHandler.removeCallbacks(mUpdateCounters);
         mBtnPlayPause.setImageDrawable(mPlayDrawable);


### PR DESCRIPTION
Every time `mCallback` is called, there was a nullity check, except when calling `onPaused`. 
This was possibly causing crashes.