### PR TITLE
Add ability to disable seeking and disable seeking ahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ player.disableControls();
 // Undoes disableControls()
 player.enableControls();
 
+// Prevents the user from seeking further than the video has played. The user can still seek freely 
+// in the portion of the video that has already been played.
+player.disableSeekAhead();
+
+//Undoes disableSeekAhead()
+player.enableSeekAhead();
+
 // Returns true if the player has prepared for playback entirely
 player.isPrepared();
 

--- a/README.md
+++ b/README.md
@@ -229,12 +229,18 @@ player.disableControls();
 // Undoes disableControls()
 player.enableControls();
 
-// Prevents the user from seeking further than the video has played. The user can still seek freely 
+// Prevents the user from seeking further than the video has played. The user can still seek freely
 // in the portion of the video that has already been played.
 player.disableSeekAhead();
 
-//Undoes disableSeekAhead()
+// Undoes disableSeekAhead()
 player.enableSeekAhead();
+
+// Prevents the user from seeking by dragging the seek bar.
+player.disableSeek();
+
+// Undoes disableSeek()
+player.enableSeek();
 
 // Returns true if the player has prepared for playback entirely
 player.isPrepared();

--- a/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
+++ b/library/src/main/java/com/afollestad/easyvideoplayer/EasyVideoPlayer.java
@@ -136,6 +136,7 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
     private int mInitialPosition = -1;
     private boolean mControlsDisabled;
     private boolean mSeekAheadDisabled;
+    private boolean mSeekDisabled;
     private int mHighestPosition = 0;
     private int mThemeColor = 0;
     private boolean mAutoFullscreen = false;
@@ -207,6 +208,7 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
                 mAutoPlay = a.getBoolean(R.styleable.EasyVideoPlayer_evp_autoPlay, false);
                 mControlsDisabled = a.getBoolean(R.styleable.EasyVideoPlayer_evp_disableControls, false);
                 mSeekAheadDisabled = a.getBoolean(R.styleable.EasyVideoPlayer_evp_disableSeekAhead, false);
+                mSeekDisabled = a.getBoolean(R.styleable.EasyVideoPlayer_evp_disableSeek, false);
 
                 mThemeColor = a.getColor(R.styleable.EasyVideoPlayer_evp_themeColor,
                     Util.resolveColor(context, R.attr.colorPrimary));
@@ -537,6 +539,14 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
 
     public void disableSeekAhead() {
         mSeekAheadDisabled = true;
+    }
+
+    public void enableSeek() {
+        mSeekDisabled = false;
+    }
+
+    public void disableSeek() {
+        mSeekDisabled = true;
     }
 
     private void setHighestPosition(int proposedPosition) {
@@ -917,6 +927,11 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
     @Override
     public void onProgressChanged(SeekBar seekBar, int value, boolean fromUser) {
         if (fromUser) {
+            if (mSeekDisabled) {
+                seekBar.setProgress(this.getCurrentPosition());
+                return;
+            }
+
             if (mSeekAheadDisabled && value > mHighestPosition) {
                 seekBar.setProgress(mHighestPosition);
                 return;
@@ -929,12 +944,12 @@ public class EasyVideoPlayer extends FrameLayout implements IUserMethods, Textur
     @Override
     public void onStartTrackingTouch(SeekBar seekBar) {
         mWasPlaying = isPlaying();
-        if (mWasPlaying) mPlayer.pause(); // keeps the time updater running, unlike pause()
+        if (mWasPlaying && !mSeekDisabled) mPlayer.pause(); // keeps the time updater running, unlike pause()
     }
 
     @Override
     public void onStopTrackingTouch(SeekBar seekBar) {
-        if (mWasPlaying) mPlayer.start();
+        if (mWasPlaying && !mSeekDisabled) mPlayer.start();
     }
 
     @Override

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -30,6 +30,7 @@
         <attr name="evp_autoPlay" format="boolean" />
 
         <attr name="evp_disableControls" format="boolean" />
+        <attr name="evp_disableSeekAhead" format="boolean" />
 
         <attr name="evp_themeColor" format="color" />
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -30,6 +30,7 @@
         <attr name="evp_autoPlay" format="boolean" />
 
         <attr name="evp_disableControls" format="boolean" />
+        <attr name="evp_disableSeek" format="boolean" />
         <attr name="evp_disableSeekAhead" format="boolean" />
 
         <attr name="evp_themeColor" format="color" />

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
     app:evp_autoFullscreen="false"
     app:evp_autoPlay="false"
     app:evp_disableSeekAhead="false"
+    app:evp_disableSeek="false"
     app:evp_customLabelText="Hello!"
     app:evp_disableControls="false"
     app:evp_hideControlsOnPlay="true"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent"
     app:evp_autoFullscreen="false"
     app:evp_autoPlay="false"
+    app:evp_disableSeekAhead="false"
     app:evp_customLabelText="Hello!"
     app:evp_disableControls="false"
     app:evp_hideControlsOnPlay="true"


### PR DESCRIPTION
This PR adds the ability to control how the user can interact with the seek bar.

_disableSeek()_ & _enableSeek()_

This disables manual seeking by dragging the seek bar, allowing the controls and progress to be shown to the user without giving them the ability to change the video position.

_disableSeekAhead()_ and _enableSeekAhead()_

This prevents the user from dragging the seek bar any further ahead than the furthest point that has already been watched, meaning the user can re-watch any portion of the video they have already seen but cannot skip ahead.

Both new options are also configurable as attributes: evp_disableSeek and evp_disableSeekAhead.